### PR TITLE
seperate class for framework and language combination

### DIFF
--- a/impl/src/main/java/org/codehaus/griffon/forge/facets/AbstractGriffonFacet.java
+++ b/impl/src/main/java/org/codehaus/griffon/forge/facets/AbstractGriffonFacet.java
@@ -2,11 +2,12 @@ package org.codehaus.griffon.forge.facets;
 
 import org.codehaus.griffon.GriffonConstants;
 import org.codehaus.griffon.forge.GriffonFacet;
+import org.codehaus.griffon.forge.utils.JavaFxJavaInjector;
+import org.codehaus.griffon.forge.utils.LanguageFrameworkInjector;
 import org.codehaus.griffon.types.FrameworkTypes;
 import org.codehaus.griffon.types.LanguageTypes;
 import org.jboss.forge.addon.dependencies.Coordinate;
 import org.jboss.forge.addon.dependencies.DependencyQuery;
-import org.jboss.forge.addon.dependencies.DependencyRepository;
 import org.jboss.forge.addon.dependencies.DependencyResolver;
 import org.jboss.forge.addon.dependencies.builder.CoordinateBuilder;
 import org.jboss.forge.addon.dependencies.builder.DependencyBuilder;
@@ -19,22 +20,14 @@ import org.jboss.forge.addon.maven.projects.MavenPluginFacet;
 import org.jboss.forge.addon.projects.Project;
 import org.jboss.forge.addon.projects.ProjectFacet;
 import org.jboss.forge.addon.projects.dependencies.DependencyInstaller;
-import org.jboss.forge.addon.resource.*;
-import org.jboss.forge.addon.templates.Template;
+import org.jboss.forge.addon.resource.ResourceFactory;
 import org.jboss.forge.addon.templates.TemplateFactory;
-import org.jboss.forge.addon.templates.freemarker.FreemarkerTemplate;
 
 import javax.inject.Inject;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public abstract class AbstractGriffonFacet extends AbstractFacet<Project>
         implements ProjectFacet, GriffonFacet, GriffonConstants {
@@ -77,124 +70,17 @@ public abstract class AbstractGriffonFacet extends AbstractFacet<Project>
     }
 
     protected void createFolders() throws IOException {
-        Project selectedProject = getFaceted();
-        DirectoryResource directoryResource = (DirectoryResource) selectedProject.getRoot();
+        LanguageFrameworkInjector injector = null;
+        switch (framework.toString() + language.toString()){
+            case "JavaFxJava":
+                injector = new JavaFxJavaInjector(getFaceted(),resourceFactory,templateFactory);
+                break;
 
-        createConfigFolder(directoryResource);
+            default:
+                throw new RuntimeException("Framework and Language combination not yet implemented");
+        }
 
-        directoryResource.getOrCreateChildDirectory("griffon-app");
-        directoryResource.getOrCreateChildDirectory("griffon-app/conf");
-        directoryResource.getOrCreateChildDirectory("griffon-app/cotrollers");
-        directoryResource.getOrCreateChildDirectory("griffon-app/i18n");
-        directoryResource.getOrCreateChildDirectory("griffon-app/lifestyle");
-        directoryResource.getOrCreateChildDirectory("griffon-app/models");
-        directoryResource.getOrCreateChildDirectory("griffon-app/resources");
-        directoryResource.getOrCreateChildDirectory("griffon-app/services");
-        directoryResource.getOrCreateChildDirectory("griffon-app/views");
-
-        createMavenFolder(directoryResource);
-    }
-
-    private void createMavenFolder(DirectoryResource rootDir) throws IOException {
-        DirectoryResource mavenDir = rootDir.getOrCreateChildDirectory("maven");
-        DirectoryResource distributionDir = rootDir.getOrCreateChildDirectory("maven/distribution");
-        DirectoryResource binDir = rootDir.getOrCreateChildDirectory("maven/distribution/bin");
-
-        copyFileFromTemplates(mavenDir,
-                "ant-macros.xml",
-                "maven" + File.separator + File.separator + "ant-macros.xml");
-
-        copyFileFromTemplates(mavenDir,
-                "assembly-descriptor.xml",
-                "maven" + File.separator + File.separator + "assembly-descriptor.xml");
-
-        copyFileFromTemplates(mavenDir,
-                "post-site.xml",
-                "maven" + File.separator + File.separator + "post-site.xml");
-
-        copyFileFromTemplates(mavenDir,
-                "prepare-izpack.xml",
-                "maven" + File.separator + File.separator + "prepare-izpack.xml");
-
-        copyFileFromTemplates(mavenDir,
-                "process-resources.xml",
-                "maven" + File.separator + File.separator + "process-resources.xml");
-
-        String projectname = getFaceted().getRoot().getName();
-
-        FileResource projectstartupsh = (FileResource) binDir.getChild(projectname);
-        projectstartupsh.createNewFile();
-
-        URL projectstartuptemplateurl = getClass().getResource("/templates" + File.separator + "javafx-java"
-                +File.separator + "maven" +File.separator + "distribution"+ File.separator + "bin"
-                +File.separator+"project.ftl");
-        URLResource projectstartuptemplateresource = resourceFactory.create(projectstartuptemplateurl).reify(URLResource.class);
-        Template template = templateFactory.create(projectstartuptemplateresource, FreemarkerTemplate.class);
-
-        Map<String, Object> templateContext = new HashMap<String,Object>();
-        templateContext.put("projectname", projectname);
-        templateContext.put("JVM_OPTS","${JVM_OPTS[@]}");
-        projectstartupsh.setContents(template.process(templateContext));
-
-        FileResource projectstartupbat = (FileResource) binDir.getChild(projectname+".bat");
-        projectstartupbat.createNewFile();
-
-        URL projectstartupbattemplateurl = getClass().getResource("/templates" + File.separator + "javafx-java"
-                +File.separator + "maven" +File.separator + "distribution"+ File.separator + "bin"
-                +File.separator+"project.bat.ftl");
-        URLResource projectstartupbattemplateresource = resourceFactory.create(projectstartupbattemplateurl).reify(URLResource.class);
-        Template template1 = templateFactory.create(projectstartupbattemplateresource, FreemarkerTemplate.class);
-
-        projectstartupbat.setContents(template1.process(templateContext));
-    }
-
-    /**
-     * Creates the config folder and its files
-     * @param rootDir
-     * @throws IOException
-     */
-    private void createConfigFolder(DirectoryResource rootDir) throws IOException {
-        DirectoryResource configDirectory = rootDir.getOrCreateChildDirectory("config");
-        DirectoryResource checkStyleDirectory = rootDir.getOrCreateChildDirectory("config/checkstyle");
-        DirectoryResource condenarcDirectory = rootDir.getOrCreateChildDirectory("config/codenarc");
-
-        FileResource headerFileTarget = (FileResource) configDirectory.getChild("HEADER");
-        headerFileTarget.createNewFile();
-
-        URL headerFileSourceUrl = getClass().getResource("/templates" + File.separator + "config"+File.separator+"HEADER.ftl");
-        URLResource headerTemplateResource = resourceFactory.create(headerFileSourceUrl).reify(URLResource.class);
-        Template template = templateFactory.create(headerTemplateResource, FreemarkerTemplate.class);
-
-        Map<String, Object> templateContext = new HashMap<String,Object>();
-        templateContext.put("yearvariable", "${year}");
-        headerFileTarget.setContents(template.process(templateContext));
-
-        // simply copying the files as there is no template processing required
-        copyFileFromTemplates(checkStyleDirectory,
-                "checkstyle.xml",
-                "config" + File.separator + "checkstyle" + File.separator + "checkstyle.xml");
-
-        copyFileFromTemplates(condenarcDirectory,
-                "codenarc.groovy",
-                "config" + File.separator + "codenarc" + File.separator + "codenarc.groovy");
-
-    }
-
-    /**
-     * Copies the given file from templates folder to the target directory
-     * @param targetDirectory
-     * @param targetFileName
-     * @param sourceFileName
-     * @throws IOException
-     */
-    private void copyFileFromTemplates(DirectoryResource targetDirectory, String targetFileName, String sourceFileName) throws IOException {
-        URL checkStyleXmlSourceUrl = getClass().getResource("/templates" + File.separator +sourceFileName);
-        FileResource checkStyleXmlTarget = (FileResource) targetDirectory.getChild(targetFileName);
-
-        if(checkStyleXmlTarget.exists())
-            checkStyleXmlTarget.delete();
-
-        Files.copy(checkStyleXmlSourceUrl.openStream(), Paths.get(checkStyleXmlTarget.getFullyQualifiedName()));
+        injector.createFolders();
     }
 
     protected void addDependencies() {

--- a/impl/src/main/java/org/codehaus/griffon/forge/facets/AbstractGriffonFacet.java
+++ b/impl/src/main/java/org/codehaus/griffon/forge/facets/AbstractGriffonFacet.java
@@ -2,6 +2,7 @@ package org.codehaus.griffon.forge.facets;
 
 import org.codehaus.griffon.GriffonConstants;
 import org.codehaus.griffon.forge.GriffonFacet;
+import org.codehaus.griffon.forge.utils.JavaFxGroovyInjector;
 import org.codehaus.griffon.forge.utils.JavaFxJavaInjector;
 import org.codehaus.griffon.forge.utils.LanguageFrameworkInjector;
 import org.codehaus.griffon.types.FrameworkTypes;
@@ -71,11 +72,13 @@ public abstract class AbstractGriffonFacet extends AbstractFacet<Project>
 
     protected void createFolders() throws IOException {
         LanguageFrameworkInjector injector = null;
-        switch (framework.toString() + language.toString()){
+        switch (framework.toString() + language.toString()) {
             case "JavaFxJava":
-                injector = new JavaFxJavaInjector(getFaceted(),resourceFactory,templateFactory);
+                injector = new JavaFxJavaInjector(getFaceted(), resourceFactory, templateFactory);
                 break;
-
+            case "JavaFxGroovy":
+                injector = new JavaFxGroovyInjector(getFaceted(), resourceFactory, templateFactory);
+                break;
             default:
                 throw new RuntimeException("Framework and Language combination not yet implemented");
         }
@@ -107,11 +110,11 @@ public abstract class AbstractGriffonFacet extends AbstractFacet<Project>
         Coordinate plugInCoordinate = CoordinateBuilder.create(baseCoordinate);
         MavenPluginFacet facet = getFaceted().getFacet(MavenPluginFacet.class);
         MavenPluginBuilder plugin = MavenPluginBuilder.create()
-                            .setCoordinate(plugInCoordinate);
+                .setCoordinate(plugInCoordinate);
         ExecutionBuilder execution = ExecutionBuilder.create()
-                                            .addGoal(goal)
-                                            .setId(id)
-                                            .setPhase(phase);
+                .addGoal(goal)
+                .setId(id)
+                .setPhase(phase);
         plugin.addExecution(execution);
         facet.addPlugin(plugin);
     }
@@ -135,15 +138,15 @@ public abstract class AbstractGriffonFacet extends AbstractFacet<Project>
         List<Coordinate> coordinates = dependencyResolver.resolveVersions(query);
 
         int i = 0;
-        for(Coordinate coordinate : coordinates){
-            if(coordinate.getVersion().startsWith(majorVersion))
+        for (Coordinate coordinate : coordinates) {
+            if (coordinate.getVersion().startsWith(majorVersion))
                 break;
             i++;
         }
 
         int v = i;
-        for(; v < coordinates.size(); v++){
-            if(!coordinates.get(v).getVersion().startsWith(majorVersion))
+        for (; v < coordinates.size(); v++) {
+            if (!coordinates.get(v).getVersion().startsWith(majorVersion))
                 break;
         }
 
@@ -166,10 +169,11 @@ public abstract class AbstractGriffonFacet extends AbstractFacet<Project>
 
     /**
      * Returns the exception as a string so that it can be printed easily
+     *
      * @param e
      * @return
      */
-    protected String getExceptionAsString(Throwable e){
+    protected String getExceptionAsString(Throwable e) {
         StringWriter sw = new StringWriter();
         e.printStackTrace(new PrintWriter(sw));
         return e.getMessage() + System.lineSeparator() + sw.toString();

--- a/impl/src/main/java/org/codehaus/griffon/forge/facets/GriffonFacetImpl_2_0.java
+++ b/impl/src/main/java/org/codehaus/griffon/forge/facets/GriffonFacetImpl_2_0.java
@@ -6,8 +6,6 @@ import org.jboss.forge.furnace.versions.Version;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -37,8 +35,6 @@ public class GriffonFacetImpl_2_0 extends AbstractGriffonFacet {
     }
 
 
-
-
     @Override
     protected void createFolders() throws IOException {
         super.createFolders();
@@ -48,11 +44,11 @@ public class GriffonFacetImpl_2_0 extends AbstractGriffonFacet {
     @Override
     protected void addDependencies() {
         super.addDependencies();
-        addDependency(GRIFFON_CORE_COMPILE,"2");
-        addDependency(GRIFFON_JAVAFX,"2");
-        addDependency(GRIFFON_GUICE,"2");
-        addDependency(GRIFFON_CORE_TEST,"2");
-        addDependency(GROOVY_ALL,"2");
+        addDependency(GRIFFON_CORE_COMPILE, "2");
+        addDependency(GRIFFON_JAVAFX, "2");
+        addDependency(GRIFFON_GUICE, "2");
+        addDependency(GRIFFON_CORE_TEST, "2");
+        addDependency(GROOVY_ALL, "2");
     }
 
     @Override

--- a/impl/src/main/java/org/codehaus/griffon/forge/utils/JavaFxGroovyInjector.java
+++ b/impl/src/main/java/org/codehaus/griffon/forge/utils/JavaFxGroovyInjector.java
@@ -2,49 +2,43 @@ package org.codehaus.griffon.forge.utils;
 
 import org.jboss.forge.addon.projects.Project;
 import org.jboss.forge.addon.resource.DirectoryResource;
-import org.jboss.forge.addon.resource.FileResource;
 import org.jboss.forge.addon.resource.ResourceFactory;
-import org.jboss.forge.addon.resource.URLResource;
-import org.jboss.forge.addon.templates.Template;
 import org.jboss.forge.addon.templates.TemplateFactory;
-import org.jboss.forge.addon.templates.freemarker.FreemarkerTemplate;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
- * @author jbuddha on 2/28/15.
+ * @author jbuddha
  */
 public class JavaFxGroovyInjector extends LanguageFrameworkInjector {
 
 
     public JavaFxGroovyInjector(Project project, ResourceFactory resourceFactory, TemplateFactory templateFactory) {
-        super(project,resourceFactory,templateFactory);
+        super(project, resourceFactory, templateFactory);
     }
-
-
 
     /**
-     * Creates the config folder and its files
-     * @param rootDir
-     * @throws java.io.IOException
+     * {@inheritDoc}
      */
-    public void createConfigFolder(DirectoryResource rootDir) throws IOException {
-       throw new RuntimeException("Not Implemented Yet");
+    @Override
+    protected void createConfigFolder(DirectoryResource rootDir) throws IOException {
+        throw new RuntimeException("Not Implemented Yet");
     }
 
-    public void createMavenFolder(DirectoryResource rootDir) throws IOException {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void createMavenFolder(DirectoryResource rootDir) throws IOException {
         throw new RuntimeException("Not Implemented Yet");
 
     }
 
-    public void createGriffonAppFolder(DirectoryResource rootDir)
-    {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void createGriffonAppFolder(DirectoryResource rootDir) {
         throw new RuntimeException("Not Implemented Yet");
     }
 

--- a/impl/src/main/java/org/codehaus/griffon/forge/utils/JavaFxGroovyInjector.java
+++ b/impl/src/main/java/org/codehaus/griffon/forge/utils/JavaFxGroovyInjector.java
@@ -1,0 +1,52 @@
+package org.codehaus.griffon.forge.utils;
+
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.resource.DirectoryResource;
+import org.jboss.forge.addon.resource.FileResource;
+import org.jboss.forge.addon.resource.ResourceFactory;
+import org.jboss.forge.addon.resource.URLResource;
+import org.jboss.forge.addon.templates.Template;
+import org.jboss.forge.addon.templates.TemplateFactory;
+import org.jboss.forge.addon.templates.freemarker.FreemarkerTemplate;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author jbuddha on 2/28/15.
+ */
+public class JavaFxGroovyInjector extends LanguageFrameworkInjector {
+
+
+    public JavaFxGroovyInjector(Project project, ResourceFactory resourceFactory, TemplateFactory templateFactory) {
+        super(project,resourceFactory,templateFactory);
+    }
+
+
+
+    /**
+     * Creates the config folder and its files
+     * @param rootDir
+     * @throws java.io.IOException
+     */
+    public void createConfigFolder(DirectoryResource rootDir) throws IOException {
+       throw new RuntimeException("Not Implemented Yet");
+    }
+
+    public void createMavenFolder(DirectoryResource rootDir) throws IOException {
+        throw new RuntimeException("Not Implemented Yet");
+
+    }
+
+    public void createGriffonAppFolder(DirectoryResource rootDir)
+    {
+        throw new RuntimeException("Not Implemented Yet");
+    }
+
+
+}

--- a/impl/src/main/java/org/codehaus/griffon/forge/utils/JavaFxJavaInjector.java
+++ b/impl/src/main/java/org/codehaus/griffon/forge/utils/JavaFxJavaInjector.java
@@ -1,0 +1,138 @@
+package org.codehaus.griffon.forge.utils;
+
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.resource.DirectoryResource;
+import org.jboss.forge.addon.resource.FileResource;
+import org.jboss.forge.addon.resource.ResourceFactory;
+import org.jboss.forge.addon.resource.URLResource;
+import org.jboss.forge.addon.templates.Template;
+import org.jboss.forge.addon.templates.TemplateFactory;
+import org.jboss.forge.addon.templates.freemarker.FreemarkerTemplate;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author jbuddha on 2/28/15.
+ */
+public class JavaFxJavaInjector extends LanguageFrameworkInjector {
+
+
+    public JavaFxJavaInjector(Project project, ResourceFactory resourceFactory, TemplateFactory templateFactory) {
+        super(project,resourceFactory,templateFactory);
+    }
+
+    @Override
+    public void createFolders() throws IOException {
+        DirectoryResource directoryResource = (DirectoryResource) project.getRoot();
+        createConfigFolder(directoryResource);
+        createGriffonAppFolder(directoryResource);
+        createMavenFolder(directoryResource);
+    }
+
+    /**
+     * Creates the config folder and its files
+     * @param rootDir
+     * @throws java.io.IOException
+     */
+    private void createConfigFolder(DirectoryResource rootDir) throws IOException {
+        DirectoryResource configDirectory = rootDir.getOrCreateChildDirectory("config");
+        DirectoryResource checkStyleDirectory = rootDir.getOrCreateChildDirectory("config/checkstyle");
+        DirectoryResource condenarcDirectory = rootDir.getOrCreateChildDirectory("config/codenarc");
+
+        FileResource headerFileTarget = (FileResource) configDirectory.getChild("HEADER");
+        headerFileTarget.createNewFile();
+
+        URL headerFileSourceUrl = getClass().getResource("/templates" + File.separator + "config"+File.separator+"HEADER.ftl");
+        URLResource headerTemplateResource = resourceFactory.create(headerFileSourceUrl).reify(URLResource.class);
+        Template template = templateFactory.create(headerTemplateResource, FreemarkerTemplate.class);
+
+        Map<String, Object> templateContext = new HashMap<String,Object>();
+        templateContext.put("yearvariable", "${year}");
+        headerFileTarget.setContents(template.process(templateContext));
+
+        // simply copying the files as there is no template processing required
+        copyFileFromTemplates(checkStyleDirectory,
+                "checkstyle.xml",
+                "config" + File.separator + "checkstyle" + File.separator + "checkstyle.xml");
+
+        copyFileFromTemplates(condenarcDirectory,
+                "codenarc.groovy",
+                "config" + File.separator + "codenarc" + File.separator + "codenarc.groovy");
+
+    }
+
+    private void createMavenFolder(DirectoryResource rootDir) throws IOException {
+        DirectoryResource mavenDir = rootDir.getOrCreateChildDirectory("maven");
+        DirectoryResource distributionDir = rootDir.getOrCreateChildDirectory("maven/distribution");
+        DirectoryResource binDir = rootDir.getOrCreateChildDirectory("maven/distribution/bin");
+
+        copyFileFromTemplates(mavenDir,
+                "ant-macros.xml",
+                "maven" + File.separator + File.separator + "ant-macros.xml");
+
+        copyFileFromTemplates(mavenDir,
+                "assembly-descriptor.xml",
+                "maven" + File.separator + File.separator + "assembly-descriptor.xml");
+
+        copyFileFromTemplates(mavenDir,
+                "post-site.xml",
+                "maven" + File.separator + File.separator + "post-site.xml");
+
+        copyFileFromTemplates(mavenDir,
+                "prepare-izpack.xml",
+                "maven" + File.separator + File.separator + "prepare-izpack.xml");
+
+        copyFileFromTemplates(mavenDir,
+                "process-resources.xml",
+                "maven" + File.separator + File.separator + "process-resources.xml");
+
+        String projectname = project.getRoot().getName();
+
+        Map<String, Object> templateContext = new HashMap<String,Object>();
+        templateContext.put("projectname", projectname);
+        templateContext.put("JVM_OPTS","${JVM_OPTS[@]}");
+
+        String templatePath = "javafx-java" + File.separator + "maven" +File.separator + "distribution"+ File.separator + "bin" +File.separator+"project.ftl";
+        processTemplate(binDir, projectname, templatePath, templateContext);
+
+        String batTemplatePath = "javafx-java" + File.separator + "maven" +File.separator + "distribution"+ File.separator + "bin" +File.separator+"project.bat.ftl";
+        processTemplate(binDir, projectname + ".bat", batTemplatePath, templateContext);
+
+    }
+
+    private void createGriffonAppFolder(DirectoryResource rootDir)
+    {
+        rootDir.getOrCreateChildDirectory("griffon-app");
+        rootDir.getOrCreateChildDirectory("griffon-app/conf");
+        rootDir.getOrCreateChildDirectory("griffon-app/cotrollers");
+        rootDir.getOrCreateChildDirectory("griffon-app/i18n");
+        rootDir.getOrCreateChildDirectory("griffon-app/lifestyle");
+        rootDir.getOrCreateChildDirectory("griffon-app/models");
+        rootDir.getOrCreateChildDirectory("griffon-app/resources");
+        rootDir.getOrCreateChildDirectory("griffon-app/services");
+        rootDir.getOrCreateChildDirectory("griffon-app/views");
+    }
+
+    /**
+     * Copies the given file from templates folder to the target directory
+     * @param targetDirectory
+     * @param targetFileName
+     * @param sourceFileName
+     * @throws IOException
+     */
+    private void copyFileFromTemplates(DirectoryResource targetDirectory, String targetFileName, String sourceFileName) throws IOException {
+        URL checkStyleXmlSourceUrl = getClass().getResource("/templates" + File.separator +sourceFileName);
+        FileResource checkStyleXmlTarget = (FileResource) targetDirectory.getChild(targetFileName);
+
+        if(checkStyleXmlTarget.exists())
+            checkStyleXmlTarget.delete();
+
+        Files.copy(checkStyleXmlSourceUrl.openStream(), Paths.get(checkStyleXmlTarget.getFullyQualifiedName()));
+    }
+}

--- a/impl/src/main/java/org/codehaus/griffon/forge/utils/JavaFxJavaInjector.java
+++ b/impl/src/main/java/org/codehaus/griffon/forge/utils/JavaFxJavaInjector.java
@@ -12,21 +12,22 @@ import org.jboss.forge.addon.templates.freemarker.FreemarkerTemplate;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @author jbuddha on 2/28/15.
+ * @author jbuddha
  */
 public class JavaFxJavaInjector extends LanguageFrameworkInjector {
 
 
     public JavaFxJavaInjector(Project project, ResourceFactory resourceFactory, TemplateFactory templateFactory) {
-        super(project,resourceFactory,templateFactory);
+        super(project, resourceFactory, templateFactory);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void createFolders() throws IOException {
         DirectoryResource directoryResource = (DirectoryResource) project.getRoot();
@@ -36,11 +37,10 @@ public class JavaFxJavaInjector extends LanguageFrameworkInjector {
     }
 
     /**
-     * Creates the config folder and its files
-     * @param rootDir
-     * @throws java.io.IOException
+     * {@inheritDoc}
      */
-    private void createConfigFolder(DirectoryResource rootDir) throws IOException {
+    @Override
+    protected void createConfigFolder(DirectoryResource rootDir) throws IOException {
         DirectoryResource configDirectory = rootDir.getOrCreateChildDirectory("config");
         DirectoryResource checkStyleDirectory = rootDir.getOrCreateChildDirectory("config/checkstyle");
         DirectoryResource condenarcDirectory = rootDir.getOrCreateChildDirectory("config/codenarc");
@@ -48,11 +48,11 @@ public class JavaFxJavaInjector extends LanguageFrameworkInjector {
         FileResource headerFileTarget = (FileResource) configDirectory.getChild("HEADER");
         headerFileTarget.createNewFile();
 
-        URL headerFileSourceUrl = getClass().getResource("/templates" + File.separator + "config"+File.separator+"HEADER.ftl");
+        URL headerFileSourceUrl = getClass().getResource("/templates" + File.separator + "config" + File.separator + "HEADER.ftl");
         URLResource headerTemplateResource = resourceFactory.create(headerFileSourceUrl).reify(URLResource.class);
         Template template = templateFactory.create(headerTemplateResource, FreemarkerTemplate.class);
 
-        Map<String, Object> templateContext = new HashMap<String,Object>();
+        Map<String, Object> templateContext = new HashMap<String, Object>();
         templateContext.put("yearvariable", "${year}");
         headerFileTarget.setContents(template.process(templateContext));
 
@@ -67,7 +67,11 @@ public class JavaFxJavaInjector extends LanguageFrameworkInjector {
 
     }
 
-    private void createMavenFolder(DirectoryResource rootDir) throws IOException {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void createMavenFolder(DirectoryResource rootDir) throws IOException {
         DirectoryResource mavenDir = rootDir.getOrCreateChildDirectory("maven");
         DirectoryResource distributionDir = rootDir.getOrCreateChildDirectory("maven/distribution");
         DirectoryResource binDir = rootDir.getOrCreateChildDirectory("maven/distribution/bin");
@@ -94,20 +98,23 @@ public class JavaFxJavaInjector extends LanguageFrameworkInjector {
 
         String projectname = project.getRoot().getName();
 
-        Map<String, Object> templateContext = new HashMap<String,Object>();
+        Map<String, Object> templateContext = new HashMap<String, Object>();
         templateContext.put("projectname", projectname);
-        templateContext.put("JVM_OPTS","${JVM_OPTS[@]}");
+        templateContext.put("JVM_OPTS", "${JVM_OPTS[@]}");
 
-        String templatePath = "javafx-java" + File.separator + "maven" +File.separator + "distribution"+ File.separator + "bin" +File.separator+"project.ftl";
+        String templatePath = "javafx-java" + File.separator + "maven" + File.separator + "distribution" + File.separator + "bin" + File.separator + "project.ftl";
         processTemplate(binDir, projectname, templatePath, templateContext);
 
-        String batTemplatePath = "javafx-java" + File.separator + "maven" +File.separator + "distribution"+ File.separator + "bin" +File.separator+"project.bat.ftl";
+        String batTemplatePath = "javafx-java" + File.separator + "maven" + File.separator + "distribution" + File.separator + "bin" + File.separator + "project.bat.ftl";
         processTemplate(binDir, projectname + ".bat", batTemplatePath, templateContext);
 
     }
 
-    private void createGriffonAppFolder(DirectoryResource rootDir)
-    {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void createGriffonAppFolder(DirectoryResource rootDir) {
         rootDir.getOrCreateChildDirectory("griffon-app");
         rootDir.getOrCreateChildDirectory("griffon-app/conf");
         rootDir.getOrCreateChildDirectory("griffon-app/cotrollers");
@@ -119,20 +126,5 @@ public class JavaFxJavaInjector extends LanguageFrameworkInjector {
         rootDir.getOrCreateChildDirectory("griffon-app/views");
     }
 
-    /**
-     * Copies the given file from templates folder to the target directory
-     * @param targetDirectory
-     * @param targetFileName
-     * @param sourceFileName
-     * @throws IOException
-     */
-    private void copyFileFromTemplates(DirectoryResource targetDirectory, String targetFileName, String sourceFileName) throws IOException {
-        URL checkStyleXmlSourceUrl = getClass().getResource("/templates" + File.separator +sourceFileName);
-        FileResource checkStyleXmlTarget = (FileResource) targetDirectory.getChild(targetFileName);
 
-        if(checkStyleXmlTarget.exists())
-            checkStyleXmlTarget.delete();
-
-        Files.copy(checkStyleXmlSourceUrl.openStream(), Paths.get(checkStyleXmlTarget.getFullyQualifiedName()));
-    }
 }

--- a/impl/src/main/java/org/codehaus/griffon/forge/utils/LanguageFrameworkInjector.java
+++ b/impl/src/main/java/org/codehaus/griffon/forge/utils/LanguageFrameworkInjector.java
@@ -1,0 +1,75 @@
+package org.codehaus.griffon.forge.utils;
+
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.resource.DirectoryResource;
+import org.jboss.forge.addon.resource.FileResource;
+import org.jboss.forge.addon.resource.ResourceFactory;
+import org.jboss.forge.addon.resource.URLResource;
+import org.jboss.forge.addon.templates.Template;
+import org.jboss.forge.addon.templates.TemplateFactory;
+import org.jboss.forge.addon.templates.freemarker.FreemarkerTemplate;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+/**
+ * Created by buddha on 2/28/15.
+ */
+public abstract class LanguageFrameworkInjector {
+
+    protected Project project;
+
+    ResourceFactory resourceFactory;
+
+    TemplateFactory templateFactory;
+
+    public LanguageFrameworkInjector(Project project, ResourceFactory resourceFactory, TemplateFactory templateFactory){
+        this.project = project;
+        this.resourceFactory = resourceFactory;
+        this.templateFactory = templateFactory;
+    }
+
+    public void createFolders() throws IOException {
+        DirectoryResource directoryResource = (DirectoryResource) project.getRoot();
+        createConfigFolder(directoryResource);
+        createGriffonAppFolder(directoryResource);
+        createMavenFolder(directoryResource);
+    }
+
+    void processTemplate(DirectoryResource targetDirectory, String targetFileName, String templateFilePath, Map templateVariables) throws IOException {
+        FileResource projectstartupsh = (FileResource) targetDirectory.getChild(targetFileName);
+        projectstartupsh.createNewFile();
+
+        URL projectstartuptemplateurl = getClass().getResource("/templates" + File.separator + templateFilePath);
+        URLResource projectstartuptemplateresource = resourceFactory.create(projectstartuptemplateurl).reify(URLResource.class);
+        Template template = templateFactory.create(projectstartuptemplateresource, FreemarkerTemplate.class);
+
+        projectstartupsh.setContents(template.process(templateVariables));
+    }
+
+    /**
+     * Copies the given file from templates folder to the target directory
+     * @param targetDirectory
+     * @param targetFileName
+     * @param sourceFileName
+     * @throws java.io.IOException
+     */
+    private void copyFileFromTemplates(DirectoryResource targetDirectory, String targetFileName, String sourceFileName) throws IOException {
+        URL checkStyleXmlSourceUrl = getClass().getResource("/templates" + File.separator +sourceFileName);
+        FileResource checkStyleXmlTarget = (FileResource) targetDirectory.getChild(targetFileName);
+
+        if(checkStyleXmlTarget.exists())
+            checkStyleXmlTarget.delete();
+
+        Files.copy(checkStyleXmlSourceUrl.openStream(), Paths.get(checkStyleXmlTarget.getFullyQualifiedName()));
+    }
+
+    public abstract void createConfigFolder(DirectoryResource directoryResource) throws IOException;
+    public abstract void createMavenFolder(DirectoryResource directoryResource) throws IOException;
+    public abstract void createGriffonAppFolder(DirectoryResource directoryResource) throws IOException;
+}

--- a/impl/src/main/java/org/codehaus/griffon/forge/utils/LanguageFrameworkInjector.java
+++ b/impl/src/main/java/org/codehaus/griffon/forge/utils/LanguageFrameworkInjector.java
@@ -9,7 +9,6 @@ import org.jboss.forge.addon.templates.Template;
 import org.jboss.forge.addon.templates.TemplateFactory;
 import org.jboss.forge.addon.templates.freemarker.FreemarkerTemplate;
 
-import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -18,7 +17,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 /**
- * Created by buddha on 2/28/15.
+ * @author jbuddha
  */
 public abstract class LanguageFrameworkInjector {
 
@@ -28,48 +27,86 @@ public abstract class LanguageFrameworkInjector {
 
     TemplateFactory templateFactory;
 
-    public LanguageFrameworkInjector(Project project, ResourceFactory resourceFactory, TemplateFactory templateFactory){
+    public LanguageFrameworkInjector(Project project, ResourceFactory resourceFactory, TemplateFactory templateFactory) {
         this.project = project;
         this.resourceFactory = resourceFactory;
         this.templateFactory = templateFactory;
     }
 
+    /**
+     * Creates necessary files and folders
+     *
+     * @throws IOException
+     */
     public void createFolders() throws IOException {
         DirectoryResource directoryResource = (DirectoryResource) project.getRoot();
         createConfigFolder(directoryResource);
         createGriffonAppFolder(directoryResource);
         createMavenFolder(directoryResource);
+
     }
 
+    /**
+     * Utility method to process an ftl file by replacing all the variables with the values provided in templateVariables
+     * and copy the final file to the targetDirectory
+     *
+     * @param targetDirectory
+     * @param targetFileName
+     * @param templateFilePath
+     * @param templateVariables
+     * @throws IOException
+     */
     void processTemplate(DirectoryResource targetDirectory, String targetFileName, String templateFilePath, Map templateVariables) throws IOException {
-        FileResource projectstartupsh = (FileResource) targetDirectory.getChild(targetFileName);
-        projectstartupsh.createNewFile();
+        FileResource targetResource = (FileResource) targetDirectory.getChild(targetFileName);
+        targetResource.createNewFile();
 
-        URL projectstartuptemplateurl = getClass().getResource("/templates" + File.separator + templateFilePath);
-        URLResource projectstartuptemplateresource = resourceFactory.create(projectstartuptemplateurl).reify(URLResource.class);
-        Template template = templateFactory.create(projectstartuptemplateresource, FreemarkerTemplate.class);
+        URL templateUrl = getClass().getResource("/templates" + File.separator + templateFilePath);
+        URLResource templateResource = resourceFactory.create(templateUrl).reify(URLResource.class);
+        Template template = templateFactory.create(templateResource, FreemarkerTemplate.class);
 
-        projectstartupsh.setContents(template.process(templateVariables));
+        targetResource.setContents(template.process(templateVariables));
     }
 
     /**
      * Copies the given file from templates folder to the target directory
+     *
      * @param targetDirectory
      * @param targetFileName
      * @param sourceFileName
      * @throws java.io.IOException
      */
-    private void copyFileFromTemplates(DirectoryResource targetDirectory, String targetFileName, String sourceFileName) throws IOException {
-        URL checkStyleXmlSourceUrl = getClass().getResource("/templates" + File.separator +sourceFileName);
-        FileResource checkStyleXmlTarget = (FileResource) targetDirectory.getChild(targetFileName);
+    protected void copyFileFromTemplates(DirectoryResource targetDirectory, String targetFileName, String sourceFileName) throws IOException {
+        URL sourceUrl = getClass().getResource("/templates" + File.separator + sourceFileName);
+        FileResource targetResource = (FileResource) targetDirectory.getChild(targetFileName);
 
-        if(checkStyleXmlTarget.exists())
-            checkStyleXmlTarget.delete();
+        if (targetResource.exists())
+            targetResource.delete();
 
-        Files.copy(checkStyleXmlSourceUrl.openStream(), Paths.get(checkStyleXmlTarget.getFullyQualifiedName()));
+        Files.copy(sourceUrl.openStream(), Paths.get(targetResource.getFullyQualifiedName()));
     }
 
-    public abstract void createConfigFolder(DirectoryResource directoryResource) throws IOException;
-    public abstract void createMavenFolder(DirectoryResource directoryResource) throws IOException;
-    public abstract void createGriffonAppFolder(DirectoryResource directoryResource) throws IOException;
+
+    /**
+     * Utility method to contain all the files inside config folder
+     *
+     * @param directoryResource
+     * @throws IOException
+     */
+    abstract void createConfigFolder(DirectoryResource directoryResource) throws IOException;
+
+    /**
+     * Utility method to contain all the files inside maven folder
+     *
+     * @param directoryResource
+     * @throws IOException
+     */
+    abstract void createMavenFolder(DirectoryResource directoryResource) throws IOException;
+
+    /**
+     * Utility method to contain all the files inside griffon-app folder
+     *
+     * @param directoryResource
+     * @throws IOException
+     */
+    abstract void createGriffonAppFolder(DirectoryResource directoryResource) throws IOException;
 }

--- a/impl/src/main/resources/META-INF/beans.xml
+++ b/impl/src/main/resources/META-INF/beans.xml
@@ -1,2 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bean-discovery-mode="all" version="1.1" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"/>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       bean-discovery-mode="all" version="1.1"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"/>

--- a/impl/src/main/resources/templates/config/checkstyle/checkstyle.xml
+++ b/impl/src/main/resources/templates/config/checkstyle/checkstyle.xml
@@ -6,7 +6,8 @@
         <!-- Blocks -->
         <module name="EmptyBlock">
             <property name="option" value="stmt"/>
-            <property name="tokens" value="LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_IF,LITERAL_FOR,LITERAL_TRY,LITERAL_WHILE,INSTANCE_INIT,STATIC_INIT"/>
+            <property name="tokens"
+                      value="LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_IF,LITERAL_FOR,LITERAL_TRY,LITERAL_WHILE,INSTANCE_INIT,STATIC_INIT"/>
         </module>
         <module name="EmptyBlock">
             <property name="option" value="text"/>

--- a/impl/src/main/resources/templates/maven/ant-macros.xml
+++ b/impl/src/main/resources/templates/maven/ant-macros.xml
@@ -24,8 +24,8 @@
                     <filter token="application.name"
                             value="${project.name}"/>
                     <filter
-                        token="application.version"
-                        value="${project.version}"/>
+                            token="application.version"
+                            value="${project.version}"/>
                     <filter token="griffon.version"
                             value="${griffon.version}"/>
                 </filterset>

--- a/impl/src/main/resources/templates/maven/assembly-descriptor.xml
+++ b/impl/src/main/resources/templates/maven/assembly-descriptor.xml
@@ -1,7 +1,7 @@
 <assembly
-    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
     <id>dist</id>
     <formats>
         <format>zip</format>

--- a/impl/src/main/resources/templates/maven/prepare-izpack.xml
+++ b/impl/src/main/resources/templates/maven/prepare-izpack.xml
@@ -2,12 +2,12 @@
     <include file="${project.build.directory}/../maven/ant-macros.xml"/>
 
     <copy-resources
-        destination="${izpack.staging.dir}"
-        source="src/main/izpack"/>
+            destination="${izpack.staging.dir}"
+            source="src/main/izpack"/>
 
     <copy-resources
-        destination="${izpack.staging.dir}/binary"
-        source="${project.build.directory}/distributions/${project.artifactId}-${project.version}-dist/${project.artifactId}-${project.version}"/>
+            destination="${izpack.staging.dir}/binary"
+            source="${project.build.directory}/distributions/${project.artifactId}-${project.version}-dist/${project.artifactId}-${project.version}"/>
 
     <taskdef name="izpack" classpath="${org.codehaus.izpack:izpack-standalone-compiler:jar}"
              classname="com.izforge.izpack.ant.IzPackTask"/>

--- a/impl/src/main/resources/templates/maven/process-resources.xml
+++ b/impl/src/main/resources/templates/maven/process-resources.xml
@@ -2,15 +2,15 @@
     <include file="${project.build.directory}/../maven/ant-macros.xml"/>
 
     <copy-resources
-        destination="${project.build.testOutputDirectory}"
-        source="src/test/resources"/>
+            destination="${project.build.testOutputDirectory}"
+            source="src/test/resources"/>
     <copy-resources
-        destination="${project.build.outputDirectory}"
-        source="src/main/resources"/>
+            destination="${project.build.outputDirectory}"
+            source="src/main/resources"/>
     <copy-resources
-        destination="${project.build.outputDirectory}"
-        source="griffon-app/resources"/>
+            destination="${project.build.outputDirectory}"
+            source="griffon-app/resources"/>
     <copy-resources
-        destination="${project.build.outputDirectory}"
-        source="griffon-app/i18n"/>
+            destination="${project.build.outputDirectory}"
+            source="griffon-app/i18n"/>
 </project>


### PR DESCRIPTION
Keeping all language and framework classes in AbstractGriffonFacet or FacetImpl will make the classes too big. Hence created utility classes that will have logic for each language and framework combination. 